### PR TITLE
8697f91re - PUSH. Les deeplinks de notifs d'actions ne fonctionnent pas

### DIFF
--- a/src/features/push-notification/hook/useInitPushNotification.ts
+++ b/src/features/push-notification/hook/useInitPushNotification.ts
@@ -42,7 +42,10 @@ export const useInitPushNotification = (props: { enable: boolean }) => {
       expoNotificationSubscription = Notifications.addNotificationResponseReceivedListener((e) => {
         try {
           if (isMounted) {
-            const link = parseHref(e.notification?.request?.content?.data?.link)
+            const possibleLinkData1 = e.notification?.request?.content?.data?.link
+            //@ts-expect-error type do not contain payload key inside trigger
+            const possibleLinkData2 = e.notification?.request?.trigger?.payload?.link
+            const link = parseHref(possibleLinkData1 ?? possibleLinkData2)
             if (link) setTimeout(() => router.replace(link), 1)
           }
         } catch (e) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved notification link parsing mechanism to handle different notification data structures
	- Added fallback method for retrieving notification links to increase reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->