### PR TITLE
chore: disable default zone filter on event list

### DIFF
--- a/src/features/events/hooks/useResetFilters.ts
+++ b/src/features/events/hooks/useResetFilters.ts
@@ -1,22 +1,16 @@
 import { useCallback } from 'react'
-import { useSession } from '@/ctx/SessionProvider'
 import { eventFiltersState } from '@/features/events/store/filterStore'
-import { useGetProfil } from '@/services/profile/hook'
 
 export default function useResetFilters() {
   const { setValue } = eventFiltersState()
-  const { isAuth } = useSession()
-  const { data: user } = useGetProfil({ enabled: isAuth })
-  const defaultAssembly = user?.instances?.assembly?.code
 
   const handleReset = useCallback(() => {
     setValue((x) => ({
       ...x,
-      zone: defaultAssembly,
       detailZone: undefined,
       search: '',
     }))
-  }, [defaultAssembly])
+  }, [])
 
   return { handleReset }
 }

--- a/src/features/events/pages/index.tsx
+++ b/src/features/events/pages/index.tsx
@@ -65,7 +65,7 @@ const EventList = ({
   } = useSuspensePaginatedEvents({
     filters: {
       searchText: filters.search,
-      zone: filters.zone ?? user.data?.instances?.assembly?.code,
+      zone: filters.zone,
       subscribedOnly: activeTab === 'myEvents',
     },
   })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined event filter reset behavior so that clearing filters now removes all selections without applying a default setting.
	- Updated event filtering to use only explicit criteria provided by the user, which may result in different event displays when no specific filter is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->