### PR TITLE
[Timeline] remove is_local property

### DIFF
--- a/src/data/restObjects/RestTimelineFeedResponse.ts
+++ b/src/data/restObjects/RestTimelineFeedResponse.ts
@@ -23,7 +23,6 @@ export interface RestTimelineFeedItem {
   image: string | null
   address: string | null
   category: string | null
-  is_local: boolean | null
   media_type: string | null
   cta_link: string | null
   cta_label: string | null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the processing of timeline items by removing an obsolete data attribute, resulting in a cleaner and more consistent handling of timeline feed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->