### PR TITLE
fix(notification): RE-3451 deduplicate token

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,11 +46,11 @@ const WaitingRoomHoc = (props: { children: ViewProps['children']; isLoading?: bo
   useInitMatomo()
   useDeepLinkHandler()
 
-  const { isLoading, isAuth } = useSession()
+  const { isLoading } = useSession()
   const { isAvailable: isUpdateAvailable, isError: isUpdateError } = useCheckStoreUpdate()
   const { isAvailable: isExpoUpdateAvailable, isError: isExpoUpdateError, isProcessing: isExpoUpdateProcessing } = useCheckExpoUpdate()
 
-  useInitPushNotification({ enable: isAuth && !isLoading && !props.isLoading })
+  useInitPushNotification()
 
   if (!props.isLoading) {
     SplashScreen.hideAsync()

--- a/src/features/push-notification/hook/useAddPushToken.ts
+++ b/src/features/push-notification/hook/useAddPushToken.ts
@@ -1,4 +1,3 @@
-import FB from '@/config/firebaseConfig'
 import { ErrorMonitor } from '@/utils/ErrorMonitor'
 import { useMutation } from '@tanstack/react-query'
 import { addPushToken } from '../api'
@@ -6,9 +5,10 @@ import { TokenCannotBeSubscribedError } from '../errors'
 
 export function useAddPushToken() {
   return useMutation({
-    mutationFn: async (variables?: { token?: string }) => {
+    mutationFn: async (variables: { token: string }) => {
+      console.log('Query token with', variables)
       return addPushToken({
-        identifier: variables?.token ?? (await FB.messaging.getToken()),
+        identifier: variables.token,
         source: 'vox',
       })
     },

--- a/src/features/push-notification/hook/useAddPushToken.ts
+++ b/src/features/push-notification/hook/useAddPushToken.ts
@@ -6,7 +6,6 @@ import { TokenCannotBeSubscribedError } from '../errors'
 export function useAddPushToken() {
   return useMutation({
     mutationFn: async (variables: { token: string }) => {
-      console.log('Query token with', variables)
       return addPushToken({
         identifier: variables.token,
         source: 'vox',

--- a/src/features/push-notification/hook/useInitPushNotification.ts
+++ b/src/features/push-notification/hook/useInitPushNotification.ts
@@ -1,56 +1,14 @@
 import { useEffect } from 'react'
 import { Platform } from 'react-native'
-import FB, { AuthorizationStatus } from '@/config/firebaseConfig'
+import FB from '@/config/firebaseConfig'
 import { ErrorMonitor } from '@/utils/ErrorMonitor'
-import isWebKit from '@/utils/isWebKit'
-import { isSupported } from '@firebase/messaging'
 import { useToastController } from '@tamagui/toast'
-import { useQuery } from '@tanstack/react-query'
 import * as Notifications from 'expo-notifications'
 import { router } from 'expo-router'
 import { parseHref } from '../utils'
-import { useAddPushToken } from './useAddPushToken'
 
-const SOURCE = 'vox'
-
-const usePermission = (options: { enable: boolean }) => {
-  return useQuery({
-    queryKey: ['permission', SOURCE],
-    queryFn: async () => {
-      if (Platform.OS === 'web' && !(await isSupported())) {
-        return false
-      }
-
-      // Special case for Safari and Edge where we can't ask notification permissions without user gesture
-      if (Platform.OS === 'web' && (await isSupported()) && isWebKit()) {
-        return Notification.permission === 'granted'
-      }
-
-      const authStatus = await FB.messaging.requestPermission({
-        sound: true,
-        alert: true,
-      })
-      return authStatus === AuthorizationStatus.AUTHORIZED || authStatus === AuthorizationStatus.PROVISIONAL
-    },
-    ...options,
-  })
-}
-
-export const useInitPushNotification = (props: { enable: boolean }) => {
-  const { mutateAsync: postPushToken } = useAddPushToken()
-  const { data: hasPermission } = usePermission({ enable: props.enable })
+export const useInitPushNotification = () => {
   const toast = useToastController()
-
-  // Permission requests shall be dissociated from handlers themselves to do a proper routing on first launch.
-  useEffect(() => {
-    if (!hasPermission || !props.enable) return
-
-    if (Platform.OS === 'web') {
-      isSupported().then(() => postPushToken({}))
-    } else {
-      postPushToken({})
-    }
-  }, [hasPermission, props.enable])
 
   useEffect(() => {
     let isMounted = true

--- a/src/hooks/notifications/useCheckNotificationsState.tsx
+++ b/src/hooks/notifications/useCheckNotificationsState.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Alert, Linking } from 'react-native'
-import fb from '@/config/firebaseConfig'
 import FB from '@/config/firebaseConfig'
 import { useAddPushToken } from '@/features/push-notification/hook/useAddPushToken'
 import { useRemovePushToken } from '@/features/push-notification/hook/useRemovePushToken'
@@ -39,12 +38,11 @@ export default function useCheckNotificationsState() {
     const { canAskAgain, status } = await getPermissionsAsync()
 
     if (canAskAgain && status !== PermissionStatus.DENIED) {
-      fb.messaging
+      FB.messaging
         .requestPermission({
           sound: true,
           alert: true,
         })
-        .finally(checkPermissions)
         .catch(() => {
           //
         })

--- a/src/hooks/notifications/useCheckNotificationsState.web.tsx
+++ b/src/hooks/notifications/useCheckNotificationsState.web.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import fb from '@/config/firebaseConfig'
 import FB from '@/config/firebaseConfig'
 import { useAddPushToken } from '@/features/push-notification/hook/useAddPushToken'
 import { useRemovePushToken } from '@/features/push-notification/hook/useRemovePushToken'
@@ -42,7 +41,7 @@ export default function useCheckNotificationsState() {
 
   const triggerNotificationRequest = useCallback(async () => {
     if (Notification.permission !== 'denied') {
-      fb.messaging.requestPermission().catch().finally(checkPermissions)
+      FB.messaging.requestPermission().catch().finally(checkPermissions)
     } else {
       toast.show('Autorisez dans les préférences.')
     }

--- a/src/hooks/notifications/useCheckNotificationsState.web.tsx
+++ b/src/hooks/notifications/useCheckNotificationsState.web.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import fb from '@/config/firebaseConfig'
-import FB, { AuthorizationStatus } from '@/config/firebaseConfig'
+import FB from '@/config/firebaseConfig'
 import { useAddPushToken } from '@/features/push-notification/hook/useAddPushToken'
 import { useRemovePushToken } from '@/features/push-notification/hook/useRemovePushToken'
 import { isSupported } from '@firebase/messaging'
@@ -26,8 +26,9 @@ export default function useCheckNotificationsState() {
 
     if (permission === 'granted' && hasBeenGrantedOnce.current === null) {
       try {
-        hasBeenGrantedOnce.current = await FB.messaging.getToken()
-        postPushToken({ token: hasBeenGrantedOnce.current })
+        const token = await FB.messaging.getToken()
+        hasBeenGrantedOnce.current = token
+        postPushToken({ token })
       } catch (e) {
         // Trigger an error if safari but not requested permission
       }
@@ -41,20 +42,7 @@ export default function useCheckNotificationsState() {
 
   const triggerNotificationRequest = useCallback(async () => {
     if (Notification.permission !== 'denied') {
-      fb.messaging
-        .requestPermission()
-        .then((response) => {
-          if (response === AuthorizationStatus.AUTHORIZED) {
-            // We pass an empty object due to typing analysis default
-            postPushToken({})
-          }
-
-          return response
-        })
-        .then(checkPermissions)
-        .catch(() => {
-          //
-        })
+      fb.messaging.requestPermission().catch().finally(checkPermissions)
     } else {
       toast.show('Autorisez dans les préférences.')
     }


### PR DESCRIPTION
@Emilien-V du coup j'ai remanié un peu le traitement.

Le useInitPushNotifications.ts gère uniquement les handlers.

Le useCheck... gère toute la partie autorisation, j'ai simplifié en appelant le traitement `checkPermissions` qui lui-même appelle la récupération/envoi de token.

De cette manière on évite l'état bizarre qui génère des doubles tokens.

J'ai utilisé en plus une constante token pour être sûr que le délais de persistance de la ref ne génère pas d'erreur.